### PR TITLE
mtda-cli: Add option to print the MTDA version

### DIFF
--- a/mtda-cli
+++ b/mtda-cli
@@ -13,6 +13,7 @@ import time
 import tty
 import sys
 import zerorpc
+import socket
 
 # Local imports
 from mtda.main import MentorTestDeviceAgent
@@ -433,9 +434,18 @@ class Application:
         storage_status = client.storage_status()
         storage_written = client.storage_bytes_written() / 1024 / 1024
         tgt_status = client.target_status()
+        try:
+            remote_version = client.agent_version()
+        except (zerorpc.RemoteError) as e:
+            if e.name == 'NameError':
+                remote_version = "<=0.5"
+            else:
+                raise e
+        host = MentorTestDeviceAgent()
 
         # Print general information
-        print("Agent          : %s%30s\r" % (remote, ""))
+        print("Host           : %s (%s)%30s\r" % (socket.gethostname(), host.version, ""))
+        print("Remote         : %s (%s)%30s\r" % (remote, remote_version, ""))
         print("Session        : %s\r" % (session))
         print("Target         : %-6s%s\r" % (tgt_status, locked))
         print("Storage on     : %-6s%s\r" % (storage_status, locked))
@@ -525,12 +535,16 @@ class Application:
                   file=sys.stderr)
             return 1
 
+    def print_version(self):
+        agent = MentorTestDeviceAgent()
+        print("MTDA version: %s" % agent.version)
+
     def main(self):
         daemonize = False
         detach = True
 
         options, stuff = getopt.getopt(
-            sys.argv[1:], 'dnr:', ['daemon', 'no-detach', 'remote='])
+            sys.argv[1:], 'dnr:v', ['daemon', 'no-detach', 'remote=', 'version'])
         for opt, arg in options:
             if opt in ('-d', '--daemon'):
                 daemonize = True
@@ -538,6 +552,9 @@ class Application:
                 detach = False
             if opt in ('-r', '--remote'):
                 self.remote = arg
+            if opt in ('-v', '--version'):
+                self.print_version()
+                sys.exit(0)
 
         # Start our server
         if daemonize is True:

--- a/mtda/__version__.py
+++ b/mtda/__version__.py
@@ -1,3 +1,3 @@
 __license__ = 'MIT'
 __copyright__ = 'Copyright (c) Mentor Embedded, 2017-2020'
-__version__ = '0.5'
+__version__ = '0.5.1'

--- a/mtda/client.py
+++ b/mtda/client.py
@@ -34,6 +34,9 @@ class Client:
             name = "mtda"
         self._session = os.getenv('MTDA_SESSION', name)
 
+    def agent_version(self):
+        return self._impl.agent_version()
+
     def command(self, args):
         return self._impl.command(args, self._session)
 

--- a/mtda/main.py
+++ b/mtda/main.py
@@ -17,6 +17,7 @@ from mtda.console.logger import ConsoleLogger
 from mtda.console.remote_output import RemoteConsoleOutput
 import mtda.keyboard.controller
 import mtda.power.controller
+from mtda import __version__
 
 _NOPRINT_TRANS_TABLE = {
     i: '.' for i in range(0, sys.maxunicode + 1) if not chr(i).isprintable()
@@ -60,6 +61,7 @@ class MentorTestDeviceAgent:
         self._lock_owner = None
         self._lock_expiry = None
         self._lock_timeout = 5  # Lock timeout (in minutes)
+        self.version = __version__
 
         # Config file in $HOME/.mtda/config
         home = os.getenv('HOME', '')
@@ -69,6 +71,9 @@ class MentorTestDeviceAgent:
         # Config file in /etc/mtda/config
         if os.path.exists('/etc'):
             self.config_files.append(os.path.join('/etc', 'mtda', 'config'))
+
+    def agent_version(self):
+        return self.version
 
     def command(self, args, session=None):
         self.mtda.debug(3, "main.command()")


### PR DESCRIPTION
Right now there is no user friendly way to find out the MTDA
version. Add -v option to print the MTDA version.

Also, add provision to print the host and remote mtda version
part of target info(mtda-cli -r).

Bump the version to 0.5.1. When quering older versions of mtda
server, which doesnot yet have this feature implemented, the
version will be printed as <=0.5.

Signed-off-by: Vijai Kumar K <Vijaikumar_Kanagarajan@mentor.com>