### PR TITLE
mtda-cli: Fix incorrect terminal restore

### DIFF
--- a/mtda-cli
+++ b/mtda-cli
@@ -10,7 +10,6 @@ import requests
 import signal
 import termios
 import time
-import tty
 import sys
 import zerorpc
 
@@ -106,10 +105,7 @@ class Application:
         # Connect to the console
         client.console_remote(self.remote)
 
-        # Save current tty settings and set to raw
-        fd = sys.stdin.fileno()
-        old_settings = termios.tcgetattr(fd)
-        tty.setraw(sys.stdin)
+        client.console_init()
 
         # Input loop
         while self.exiting is False:
@@ -120,9 +116,7 @@ class Application:
             else:
                 server.console_send(c, True)
 
-        # Restore tty settings
         print("\r\nThank you for using MTDA!\r\n\r\n")
-        termios.tcsetattr(sys.stdin.fileno(), termios.TCSADRAIN, old_settings)
 
     def console_menukey(self, c):
         server = self.client()

--- a/mtda/client.py
+++ b/mtda/client.py
@@ -46,6 +46,9 @@ class Client:
     def console_getkey(self):
         return self._agent.console_getkey()
 
+    def console_init(self):
+        return self._agent.console_init()
+
     def console_head(self):
         return self._impl.console_head(self._session)
 

--- a/mtda/console/input.py
+++ b/mtda/console/input.py
@@ -30,5 +30,5 @@ class ConsoleInput:
         fcntl.ioctl(self.fd, termios.TIOCSTI, b'\0')
 
     def cleanup(self):
-        termios.tcsetattr(self.fd, termios.TCSAFLUSH, self.old)
+        termios.tcsetattr(self.fd, termios.TCSADRAIN, self.old)
 

--- a/mtda/main.py
+++ b/mtda/main.py
@@ -10,6 +10,7 @@ import sys
 import time
 import zlib
 import zmq
+import tty
 
 # Local imports
 from mtda.console.input import ConsoleInput
@@ -83,14 +84,18 @@ class MentorTestDeviceAgent:
 
     def console_getkey(self):
         self.mtda.debug(3, "main.console_getkey()")
-
-        if self.console_input is None:
-            self.console_input = ConsoleInput()
-            self.console_input.start()
-        result = self.console_input.getkey()
-
+        result = None
+        try:
+            result = self.console_input.getkey()
+        except AttributeError:
+            print("Initialize the console using console_init first")
         self.mtda.debug(3, "main.console_getkey(): %s" % str(result))
         return result
+
+    def console_init(self):
+        self.console_input = ConsoleInput()
+        self.console_input.start()
+        tty.setraw(sys.stdin)
 
     def console_clear(self, session=None):
         self.mtda.debug(3, "main.console_clear()")


### PR DESCRIPTION
From commit 26bbee6, the atexit based console cleanup incorrectly
restores the terminal to raw mode.

Remove the terminal restore in the main application and move console
init to a separate function. Let the atexit based cleanup routine
restore the correct settings back.

Signed-off-by: Vijai Kumar K <Vijaikumar_Kanagarajan@mentor.com>