### PR TITLE
console: support switching between the console and the monitor

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -145,6 +145,7 @@ The following key bindings may be used to control MTDA from the interactive cons
  * ``Ctrl-a`` + ``a``: acquire the target
  * ``Ctrl-a`` + ``b``: paste console buffer to pastebin.com
  * ``Ctrl-a`` + ``i``: print target information (power status, SD card, USB ports, etc.)
+ * ``Ctrl-a`` + ``m``: switch between the monitor and the console
  * ``Ctrl-a`` + ``p``: toggle power on/off
  * ``Ctrl-a`` + ``q``: quit
  * ``Ctrl-a`` + ``r``: release the target

--- a/mtda-cli
+++ b/mtda-cli
@@ -40,6 +40,7 @@ class Application:
         self.logfile = "/var/log/mtda.log"
         self.pidfile = "/var/run/mtda.pid"
         self.exiting = False
+        self.channel = "console"
 
     def daemonize(self):
         context = daemon.DaemonContext(
@@ -120,8 +121,9 @@ class Application:
         if sys.stdin.isatty():
             self.target_info()
 
-        # Connect to the console
+        # Connect to the consoles
         client.console_remote(self.remote)
+        client.monitor_remote(self.remote)
 
         client.console_init()
 
@@ -136,12 +138,15 @@ class Application:
             if prefix_key is not None and c == prefix_key:
                 c = client.console_getkey()
                 self.console_menukey(c)
-            else:
+            elif self.channel == 'console':
                 server.console_send(c, True)
+            else:
+                server.monitor_send(c, True)
 
         print("\r\nThank you for using MTDA!\r\n\r\n")
 
     def console_menukey(self, c):
+        client = self.agent
         server = self.client()
         if c == 'a':
             status = server.target_lock()
@@ -151,6 +156,16 @@ class Application:
             self.console_pastebin()
         elif c == 'i':
             self.target_info()
+        elif c == 'm':
+            if self.channel == 'console':
+                # Switch the alternate screen buffer
+                print("\x1b[?1049h") # same as tput smcup
+                self.channel = 'monitor'
+            else:
+                # Return to the main screen buffer
+                print("\x1b[?1049l") # same as tput rmcup
+                self.channel = 'console'
+            client.console_toggle()
         elif c == 'p':
             previous_status = server.target_status()
             server.target_toggle()
@@ -219,7 +234,7 @@ class Application:
             sys.stdout.flush()
 
     def console_send(self, args):
-        self.client().console_send(args[0])
+         self.client().console_send(args[0])
 
     def console_tail(self, args):
         line = self.client().console_tail()

--- a/mtda/client.py
+++ b/mtda/client.py
@@ -95,6 +95,9 @@ class Client:
     def console_send(self, data, raw=False):
         return self._impl.console_send(data, raw, self._session)
 
+    def console_toggle(self):
+        return self._agent.console_toggle(self._session)
+
     def console_tail(self):
         return self._impl.console_tail(self._session)
 
@@ -106,6 +109,9 @@ class Client:
 
     def keyboard_write(self, data):
         return self._impl.keyboard_write(data, self._session)
+
+    def monitor_remote(self, host):
+        return self._agent.monitor_remote(host)
 
     def monitor_send(self, data, raw=False):
         return self._impl.monitor_send(data, raw, self._session)

--- a/mtda/console/logger.py
+++ b/mtda/console/logger.py
@@ -16,11 +16,13 @@ import os
 import sys
 import threading
 import time
+import zmq
 
 
 class ConsoleLogger:
 
-    def __init__(self, mtda, console, socket=None, power_controller=None):
+    def __init__(self, mtda, console, socket=None,
+                 power_controller=None, topic=b'CON'):
         self.mtda = mtda
         self.console = console
         self._prompt = "=> "
@@ -33,6 +35,7 @@ class ConsoleLogger:
         self.rx_lock = threading.Lock()
         self.rx_cond = threading.Condition(self.rx_lock)
         self.socket = socket
+        self.topic = topic
         self.basetime = 0
         self.timestamps = False
 
@@ -171,6 +174,7 @@ class ConsoleLogger:
     def _print(self, data):
         if self.prints is True:
             if self.socket is not None:
+                self.socket.send(self.topic, flags=zmq.SNDMORE)
                 self.socket.send(data)
             else:
                 # Write to stdout if received are not pushed to the network


### PR DESCRIPTION
The interactive console now supports setups having both a console and a
monitor and switching between them (ctrl-a m). The ZeroMQ publisher now
has a CON(sole) and a MON(itor) topic to stream data from these two
consoles to clients. pause(), resume() and toggle() methods were added
to the console output class. In order to switch to the monitor, the
client will pause the console (data received will be logged into a ring
buffer) and the monitor output resumed. Interactive input to the monitor
will be the subject of a later changeset.

Signed-off-by: Cedric Hombourger <Cedric_Hombourger@mentor.com>