### PR TITLE
Update to the latest kas

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -216,10 +216,10 @@ where the following functions will be exposed:
 Building the microSD card image
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use ``kas-docker`` to build a Debian image for the nanoPI NEO-LTS with MTDA
+Use ``kas-container`` to build a Debian image for the nanoPI NEO-LTS with MTDA
 pre-installed::
 
-    $ kas-docker --isar build kas/mtda-nanopi-neo.yml
+    $ kas-container build kas/mtda-nanopi-neo.yml
 
 Insert a microSD card to your system and write the generated image::
 

--- a/kas/mtda-nanopi-neo.yml
+++ b/kas/mtda-nanopi-neo.yml
@@ -1,9 +1,10 @@
 header:
-  version: 8
+  version: 10
 
 machine: nanopi-neo
 distro: debian-buster
 target: isar-image-base
+build_system: isar
 
 repos:
   this:

--- a/kas/mtda-qemu-amd64.yml
+++ b/kas/mtda-qemu-amd64.yml
@@ -1,9 +1,10 @@
 header:
-  version: 8
+  version: 10
 
 machine: qemuamd64
 distro: debian-buster
 target: isar-image-base
+build_system: isar
 
 repos:
   this:


### PR DESCRIPTION
With the latest kas, we can specify the build system type in the
yaml file itself.

Also, kas-docker is renamed to kas-container.

Signed-off-by: Vijai Kumar K <Vijaikumar_Kanagarajan@mentor.com>