### PR TITLE
mtda/main.py: Initialize socket attribute

### DIFF
--- a/mtda/main.py
+++ b/mtda/main.py
@@ -49,6 +49,7 @@ class MultiTenantDeviceAccess:
     def __init__(self):
         self.config_files = ['mtda.ini']
         self.console = None
+        self.socket = None
         self.console_logger = None
         self.monitor = None
         self.monitor_logger = None


### PR DESCRIPTION
When mtda server is run without any config file, the mtda-client fails
with the below error.

  File "/usr/lib/python3/dist-packages/mtda/main.py", line 1231, in notify
    if self.socket is not None:
AttributeError: 'MultiTenantDeviceAccess' object has no attribute 'socket'

Right now, the socket attribute is created only during the console
initialization. This causes runtime failures when there is no configfile
or console section in a config file.

Initialize socket attribute to None in init method.

Signed-off-by: Vijai Kumar K <Vijaikumar_Kanagarajan@mentor.com>