### PR TITLE
images/mtda-image.inc : Add lavapdu-client package

### DIFF
--- a/meta-isar/recipes-core/images/mtda-image.inc
+++ b/meta-isar/recipes-core/images/mtda-image.inc
@@ -20,6 +20,7 @@ IMAGE_INSTALL += "                       \
 IMAGE_PREINSTALL += "                    \
     iproute2                             \
     isc-dhcp-client                      \
+    lavapdu-client                       \
     mtda                                 \
     mtda-usb-functions                   \
     network-manager                      \


### PR DESCRIPTION
Requires the package for the pduclient communication
between assist board and DUT.

Signed-off-by: Sarath P T <Sarath_PT@mentor.com>