### PR TITLE
power/gpio: support multiple pins

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -311,7 +311,7 @@ Hit ``i`` to enter the input mode and type the following configuration::
 
     [power]
     variant=gpio
-    pin=203
+    pins=203
 
     [keyboard]
     variant=hid
@@ -357,7 +357,7 @@ The following configuration file may be used for the DE0-Nano-SoC::
 
     [power]
     variant=gpio
-    pin=203
+    pins=203
 
     [sdmux]
     variant=samsung

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -197,8 +197,12 @@ The ``gpio`` driver may be used to control a simple electric relay using GPIO
 lines from the system running the MTDA agent. The following settings are
 supported:
 
-* ``pin``: integer [required]
+* ``pin``: integer [deprecated, required]
     Specify the GPIO pin number to be used to control the relay.
+
+* ``pins``: string [required]
+    Comma separated list of GPIO pins to toggle relays driving power of
+    the device.
 
 ``pduclient`` driver settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mtda.ini
+++ b/mtda.ini
@@ -85,7 +85,7 @@ rate=115200
 variant=aviosys_8800
 
 # variant=gpio
-# pin=48
+# pins=48
 
 # variant=pduclient
 # daemon=134.86.60.40


### PR DESCRIPTION
The gpio driver may now be configured with a comma separated list
of pins for systems requiring multiple power delivery units.

Signed-off-by: Cedric Hombourger <cedric_hombourger@mentor.com>