### PR TITLE
console: start/stop timestamps when user-defined strings are received

### DIFF
--- a/mtda.ini
+++ b/mtda.ini
@@ -70,6 +70,15 @@ rate=115200
 # host=192.168.2.176
 # port=5000
 
+# whether to prefix console output with timestamps
+timestamps = no
+
+# when to start/stop the stopwatch:
+# start as soon we get the U-Boot banner
+# and stop when we get a login prompt
+time-from  = U-Boot
+time-until = login:
+
 # ---------------------------------------------------------------------------
 # Power Control settings
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Introduce the 'time-from' and 'time-until' settings to automatically start/stop
printing timestamps in front of console lines.

Signed-off-by: Cedric Hombourger <Cedric_Hombourger@mentor.com>