### PR TITLE
mtda-cli: let user configure its own pastebin service

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -27,6 +27,17 @@ General settings
       instead of ``losetup`` and ``mount``. This feature is experimental and
       requires ``partitionfs``, ``fuseext2`` and ``fusefat``.
 
+* ``pastebin``: section [optional]
+  Support for posting console content to services like pastebin.com. An API key
+  is required and may be specified with:
+
+  * ``api-key``: string [optional]
+    Define the API key to be passed to the pastebin service
+
+  * ``endpoint``: string [optional]
+    Specify an alternate pastebin service (defaults to
+    http://pastebin.com/api/api_post.php)
+
 * ``ui``: section [optional]
   User Interface settings for the console. This is relevant only for MTDA clients.
 

--- a/mtda-cli
+++ b/mtda-cli
@@ -29,9 +29,6 @@ from mtda.main import MultiTenantDeviceAccess
 from mtda.client import Client
 from mtda.console.screen import ScreenOutput
 
-PASTEBIN_API_KEY = "1a265f6e04cf3c1df5e153018390eb29"
-PASTEBIN_ENDPOINT = "http://pastebin.com/api/api_post.php"
-
 
 class Application:
 
@@ -203,13 +200,22 @@ class Application:
             server.usb_toggle(1)
 
     def console_pastebin(self):
+        client = self.agent
+        server = self.client()
+        api_key = client.pastebin_api_key()
+        endpoint = client.pastebin_endpoint()
+        if api_key is None or endpoint is None:
+            server.console_print(
+                    "\r\n*** key/endpoint for pastebin "
+                    "are not configured! ***\r\n")
+            return
         data = {
-                'api_dev_key': PASTEBIN_API_KEY,
+                'api_dev_key': api_key,
                 'api_option': 'paste',
                 'api_paste_code': self.client().console_dump(),
                 'api_paste_format': 'python'
                }
-        r = requests.post(url=PASTEBIN_ENDPOINT, data=data)
+        r = requests.post(url=endpoint, data=data)
         server = self.client()
         server.console_print(
             "\r\n*** console buffer posted to %s ***\r\n" % (r.text))

--- a/mtda.ini
+++ b/mtda.ini
@@ -21,6 +21,13 @@ debug = 0
 fuse = no
 
 # ---------------------------------------------------------------------------
+# Support for posting console output to pastebin
+# ---------------------------------------------------------------------------
+# [pastebin]
+# api-key = 1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# endpoint = http://pastebin.com/api/api_post.php
+
+# ---------------------------------------------------------------------------
 # Remote settings
 # ---------------------------------------------------------------------------
 # Set "control" to the TCP/IP port number for the control interface

--- a/mtda/client.py
+++ b/mtda/client.py
@@ -126,6 +126,12 @@ class Client:
     def monitor_wait(self, what, timeout=None):
         return self._impl.monitor_wait(what, timeout, self._session)
 
+    def pastebin_api_key(self):
+        return self._agent.pastebin_api_key()
+
+    def pastebin_endpoint(self):
+        return self._agent.pastebin_endpoint()
+
     def power_locked(self):
         return self._impl.power_locked(self._session)
 

--- a/mtda/main.py
+++ b/mtda/main.py
@@ -39,6 +39,7 @@ _NOPRINT_TRANS_TABLE = {
 }
 
 DEFAULT_PREFIX_KEY = 'ctrl-a'
+DEFAULT_PASTEBIN_EP = "http://pastebin.com/api/api_post.php"
 
 
 def _make_printable(s):
@@ -69,6 +70,8 @@ class MultiTenantDeviceAccess:
         self.power_off_script = None
         self.power_monitors = []
         self.sdmux_controller = None
+        self._pastebin_api_key = None
+        self._pastebin_endpoint = None
         self._storage_mounted = False
         self._storage_opened = False
         self._writer = None
@@ -426,6 +429,14 @@ class MultiTenantDeviceAccess:
 
         self.mtda.debug(3, "main.monitor_wait(): %s" % str(result))
         return result
+
+    def pastebin_api_key(self):
+        self.mtda.debug(3, "main.pastebin_api_key()")
+        return self._pastebin_api_key
+
+    def pastebin_endpoint(self):
+        self.mtda.debug(3, "main.pastebin_endpoint()")
+        return self._pastebin_endpoint
 
     def power_locked(self, session=None):
         self.mtda.debug(3, "main.power_locked()")
@@ -949,6 +960,8 @@ class MultiTenantDeviceAccess:
             self.load_main_config(parser)
         if parser.has_section('environment'):
             self.load_environment(parser)
+        if parser.has_section('pastebin'):
+            self.load_pastebin_config(parser)
         if parser.has_section('remote'):
             self.load_remote_config(parser)
         self.load_timeouts_config(parser)
@@ -1083,6 +1096,13 @@ class MultiTenantDeviceAccess:
         except ImportError:
             print('monitor "%s" could not be found/loaded!' % (
                 variant), file=sys.stderr)
+
+    def load_pastebin_config(self, parser):
+        self.mtda.debug(3, "main.load_pastebin_config()")
+        self._pastebin_api_key = parser.get('pastebin', 'api-key',
+                                            fallback='')
+        self._pastebin_endpoint = parser.get('pastebin', 'endpoint',
+                                             fallback=DEFAULT_PASTEBIN_EP)
 
     def load_power_config(self, parser):
         self.mtda.debug(3, "main.load_power_config()")


### PR DESCRIPTION
A [pastebin] section may not be added to the client-side configuration
file to specify the pastebin service to use and its API key.

Closes: #69
Signed-off-by: Cedric Hombourger <Cedric_Hombourger@mentor.com>