### PR TITLE
fix(debian): resolve file conflict between mtda-service and mtda-systemd-helper

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -48,6 +48,8 @@ Package: mtda-systemd-helper
 Architecture: all
 Multi-Arch: foreign
 Depends: mtda-common
+Replaces: mtda-service (<< 0.42)
+Breaks: mtda-service (<< 0.42)
 Description: handle dynamic config fragments and restart mtda-service
  on config changes.
 


### PR DESCRIPTION
The file `/usr/sbin/mtda-systemd-helper` was moved from mtda-service to the new mtda-systemd-helper package, causing installation conflicts during upgrade. Handle the file transition by adding appropriate Debian control fields.