### PR TITLE
chore: update isar layers

### DIFF
--- a/kas/common/base.lock.yml
+++ b/kas/common/base.lock.yml
@@ -3,4 +3,4 @@ header:
 overrides:
     repos:
         isar:
-            commit: df63cc01345e07586ba483ab4b57febaa6067193
+            commit: 3c16bca058080569572d45e1b129f6b7b9fe7c36

--- a/kas/opt/ab-rootfs.lock.yml
+++ b/kas/opt/ab-rootfs.lock.yml
@@ -3,4 +3,4 @@ header:
 overrides:
     repos:
         cip-core:
-            commit: 8116ab220fd5054ae918c0bf2e3d3e3f3d1de914
+            commit: 269faa05911286b1c55f4ca3ba08b46d878f903e


### PR DESCRIPTION
This brings the following relevant changes:

isar:
* dpkg-prebuilt: Skip local isar-apt copy
* deb-dl-dir: Fail if "apt-cache dumpavail" returns empty list
* Create separate BOM for external initrd

isar-cip-core:
* linux-cip: Update to 5.10.240-cip63 and 6.12.43-cip7
* u-boot: Update to v2025.07