### PR TITLE
fix: storage_flush called before write complete

### DIFF
--- a/mtda/client.py
+++ b/mtda/client.py
@@ -333,8 +333,11 @@ class ImageFile:
     def flush(self):
         # Wait for background writes to complete
         agent = self._agent
-
         self._socket.send(b'')
+        writing = True
+        while writing:
+            _, writing, written = agent.storage_status()
+            time.sleep(0.5)
         success = agent.storage_flush(self._totalsent)
         self._socket.close()
         self._socket = None


### PR DESCRIPTION
storage_flush on client side is called before the write is completed and thread.join() in writer takes time, hence timeout observed in client side.

Tested-by: Vidyasagar G C <vidyasagar.gc@siemens.com>
Signed-off-by: Shivaschandra KL <shivaschandra.k-l@siemens.com>
