### PR TITLE
fix: storage_flush check thread exists before joining

### DIFF
--- a/mtda/storage/writer.py
+++ b/mtda/storage/writer.py
@@ -93,8 +93,9 @@ class AsyncImageWriter:
         self._receiving = False
         self._size = size
 
-        self.mtda.debug(2, "storage.writer.flush(): waiting on thread...")
-        self._thread.join()
+        if self._thread is not None:
+            self.mtda.debug(2, "storage.writer.flush(): waiting on thread...")
+            self._thread.join()
         result = not self._failed
 
         self.mtda.debug(3, f"storage.writer.flush(): {result}")


### PR DESCRIPTION
Some issue are observed during storage write, it happens when the storage_flush is called by client. At server thread join is tried when flush is called to writer, since the stop has already been called thread for the instance is already reinitialized to none, Due to this at client we observe errors stating calling join on None type.

Tested-by: Gourav Singh <gourav.singh.ext@siemens.com>
Signed-off-by: Shivaschandra KL <shivaschandra.k-l@siemens.com>