### PR TITLE
Fix usbf storage write without CoW device

### DIFF
--- a/mtda/main.py
+++ b/mtda/main.py
@@ -24,6 +24,7 @@ import time
 # Local imports
 import mtda.constants as CONSTS
 from mtda import __version__
+from mtda.storage.helpers.image import MissingCowDeviceError
 
 # Pyro
 try:
@@ -744,7 +745,10 @@ class MultiTenantDeviceAccess:
             if self.storage_locked(session):
                 raise RuntimeError('cannot commit changes, '
                                    'storage is locked!')
-            result = self.storage.commit()
+            try:
+                result = self.storage.commit()
+            except MissingCowDeviceError as e:
+                raise OSError(str(e)) from e
 
         self.mtda.debug(3, f"main.storage_commit(): {result}")
         return result
@@ -764,7 +768,10 @@ class MultiTenantDeviceAccess:
             if self.storage_locked(session):
                 raise RuntimeError('cannot rollback changes, '
                                    'storage is locked!')
-            result = self.storage.rollback()
+            try:
+                result = self.storage.rollback()
+            except MissingCowDeviceError as e:
+                raise OSError(str(e)) from e
 
         self.mtda.debug(3, f"main.storage_rollback(): {result}")
         return result

--- a/mtda/storage/helpers/image.py
+++ b/mtda/storage/helpers/image.py
@@ -69,7 +69,7 @@ class Image(StorageController):
             self.handle = None
             self.bmapDict = None
             if hasattr(self, 'rollback'):
-                self.rollback()
+                self.rollback(ignore_missing=True)
             try:
                 subprocess.check_output(["sync"])
             except subprocess.CalledProcessError:

--- a/mtda/storage/helpers/image.py
+++ b/mtda/storage/helpers/image.py
@@ -31,6 +31,15 @@ class BmapWriteError(OSError):
     pass
 
 
+class MissingCowDeviceError(FileNotFoundError):
+    """
+    A operation on a cow device was requested, but
+    none was configured.
+    """
+    def __init__(self, operation):
+        super().__init__(f'{operation} failed: no CoW device was configured!')
+
+
 class Image(StorageController):
     _is_storage_mounted = False
 

--- a/mtda/storage/qemu.py
+++ b/mtda/storage/qemu.py
@@ -15,7 +15,7 @@ import subprocess
 
 # Local imports
 import mtda.constants as CONSTS
-from mtda.storage.helpers.image import Image
+from mtda.storage.helpers.image import Image, MissingCowDeviceError
 from mtda.utils import Size
 
 
@@ -103,15 +103,23 @@ class QemuController(Image):
         return result
 
     def commit(self, ignore_missing=False):
-        if self.cow:
-            cmd = ['qemu-img', 'commit', self.cow]
-            subprocess.check_call(cmd)
+        if self.cow is None:
+            if ignore_missing:
+                return
+            raise MissingCowDeviceError('commit')
+
+        cmd = ['qemu-img', 'commit', self.cow]
+        subprocess.check_call(cmd)
 
     def rollback(self, ignore_missing=False):
-        if self.cow:
-            cmd = ['qemu-img', 'create', '-F', 'raw', '-f', 'qcow2',
-                   '-b', self.file, self.cow, f'{self.size}M']
-            subprocess.check_call(cmd)
+        if self.cow is None:
+            if ignore_missing:
+                return
+            raise MissingCowDeviceError('rollback')
+
+        cmd = ['qemu-img', 'create', '-F', 'raw', '-f', 'qcow2',
+               '-b', self.file, self.cow, f'{self.size}M']
+        subprocess.check_call(cmd)
 
     def supports_hotplug(self):
         return True

--- a/mtda/storage/qemu.py
+++ b/mtda/storage/qemu.py
@@ -102,12 +102,12 @@ class QemuController(Image):
         self.lock.release()
         return result
 
-    def commit(self):
+    def commit(self, ignore_missing=False):
         if self.cow:
             cmd = ['qemu-img', 'commit', self.cow]
             subprocess.check_call(cmd)
 
-    def rollback(self):
+    def rollback(self, ignore_missing=False):
         if self.cow:
             cmd = ['qemu-img', 'create', '-F', 'raw', '-f', 'qcow2',
                    '-b', self.file, self.cow, f'{self.size}M']

--- a/mtda/storage/usbf.py
+++ b/mtda/storage/usbf.py
@@ -147,8 +147,10 @@ class UsbFunctionController(Image):
         dropin = os.path.join(dir, 'auto-dep-storage-cow.conf')
         SystemdDeviceUnit.create_device_dependency(dropin, self.cow_device)
 
-    def rollback(self):
+    def rollback(self, ignore_missing=False):
         if self.cow_device is None:
+            if ignore_missing:
+                return
             raise MissingCowDeviceError('rollback')
 
         subprocess.run(['/sbin/kpartx', '-dv', f"/dev/mapper/{DM_COW}"])
@@ -164,8 +166,10 @@ class UsbFunctionController(Image):
                f"{self.base_device} {self.cow_device} P 8"]
         subprocess.check_call(cmd)
 
-    def commit(self):
+    def commit(self, ignore_missing=False):
         if self.cow_device is None:
+            if ignore_missing:
+                return
             raise MissingCowDeviceError('commit')
 
         # Trigger merge

--- a/mtda/storage/usbf.py
+++ b/mtda/storage/usbf.py
@@ -19,7 +19,7 @@ import time
 
 # Local imports
 import mtda.constants as CONSTS
-from mtda.storage.helpers.image import Image
+from mtda.storage.helpers.image import Image, MissingCowDeviceError
 from mtda.support.usb import Composite
 from mtda.utils import SystemdDeviceUnit
 
@@ -149,7 +149,7 @@ class UsbFunctionController(Image):
 
     def rollback(self):
         if self.cow_device is None:
-            raise FileNotFoundError('no CoW device was configured!')
+            raise MissingCowDeviceError('rollback')
 
         subprocess.run(['/sbin/kpartx', '-dv', f"/dev/mapper/{DM_COW}"])
         cmd = ['/sbin/dmsetup', 'remove', DM_COW]
@@ -166,7 +166,7 @@ class UsbFunctionController(Image):
 
     def commit(self):
         if self.cow_device is None:
-            raise FileNotFoundError('no CoW device was configured!')
+            raise MissingCowDeviceError('commit')
 
         # Trigger merge
         cmd = ['/sbin/dmsetup', 'suspend', DM_BASE]


### PR DESCRIPTION
The bug arises from inconsistent semantics of the storage backends (usbf and qemu) regarding if a CoW device is needed when calling CoW operations or not. We now align these so that the caller does not need to care.

closes: #560 