### PR TITLE
Fix: mtda-rpi4b-ebg target

### DIFF
--- a/kas/common/base.lock.yml
+++ b/kas/common/base.lock.yml
@@ -3,4 +3,4 @@ header:
 overrides:
     repos:
         isar:
-            commit: 680c07ee072483329885ba08b7b2b1f763326dc8
+            commit: c92b7c95b0b867aa477396cb331c28601ce9e5ec

--- a/kas/debian/mtda-rpi4b-ebg.yml
+++ b/kas/debian/mtda-rpi4b-ebg.yml
@@ -16,5 +16,5 @@ header:
   version: 17
   includes:
     - kas/common/base.yml
-    - kas/debian/bookworm-base.yml
+    - kas/debian/trixie-base.yml
     - kas/opt/ab-rootfs.yml

--- a/kas/opt/ab-rootfs.lock.yml
+++ b/kas/opt/ab-rootfs.lock.yml
@@ -3,4 +3,4 @@ header:
 overrides:
     repos:
         cip-core:
-            commit: c75b584f32411a03c3ca9a9b023cd4e74d79d32f
+            commit: 2647471156b128bf8b0fb1d726bd05099fbbe1bd

--- a/kas/opt/ab-rootfs.yml
+++ b/kas/opt/ab-rootfs.yml
@@ -18,7 +18,7 @@ repos:
 
   cip-core:
     url: https://gitlab.com/cip-project/cip-core/isar-cip-core.git
-    branch: next
+    branch: master
 
 local_conf_header:
   partition-uuids: |


### PR DESCRIPTION
This fixes the mtda-rpi4b-ebg which can be used to integrated full swupdate support.

Multiple things were fixed:

- Update isar and isar-cip core to to their current master. Fixes the reference to stale commits (isar-cip-core next).
  **Note:It's not recommended to reference isar-cip-core next since it's getting rebased from time to time**
- Switch to debian-trixie: The reason for this was to update u-boot (u-boot-rpi) which contains important fixes for booting on the rpi4b platform.


