### PR TITLE
chore: update layer dependencies

### DIFF
--- a/kas/common/base.lock.yml
+++ b/kas/common/base.lock.yml
@@ -3,4 +3,4 @@ header:
 overrides:
     repos:
         isar:
-            commit: 2efd5d4ca3b4abf2386fe0089594029becdf2801
+            commit: 34c3cda51b46a2a2a405e472a3c4b88c820c765e

--- a/kas/opt/ab-rootfs.lock.yml
+++ b/kas/opt/ab-rootfs.lock.yml
@@ -3,4 +3,4 @@ header:
 overrides:
     repos:
         cip-core:
-            commit: 31002450feccb382b604f43d9cddd3b229619ad4
+            commit: 120bb7b586d1f69f234e2dd6754530fd27e873d1


### PR DESCRIPTION
This fixes the build issue of gnuefi on all targets using the efibootguard bootloader.