### PR TITLE
chore(mtda-isar): add missing maintainer info

### DIFF
--- a/meta-isar/recipes-conf/local-settings/local-settings_1.0.bb
+++ b/meta-isar/recipes-conf/local-settings/local-settings_1.0.bb
@@ -7,6 +7,8 @@
 
 inherit dpkg-raw
 
+MAINTAINER = "mtda-users <mtda-users@googlegroups.com>"
+
 include local.inc
 
 do_install() {

--- a/meta-isar/recipes-conf/mtda-repo/mtda-repo_0.1.bb
+++ b/meta-isar/recipes-conf/mtda-repo/mtda-repo_0.1.bb
@@ -2,6 +2,7 @@
 # Copyright (c) 2026 Siemens AG
 # SPDX-License-Identifier: MIT
 
+MAINTAINER = "mtda-users <mtda-users@googlegroups.com>"
 DESCRIPTION = "inject mtda binary package feeds into runtime image"
 
 MTDA_APT_URI ??= "https://apt.fury.io/mtda/"

--- a/meta-isar/recipes-www/pyodide/pyodide_0.29.0.bb
+++ b/meta-isar/recipes-www/pyodide/pyodide_0.29.0.bb
@@ -9,6 +9,7 @@ inherit dpkg-raw
 
 PR = "1"
 CHANGELOG_V = "${PV}-${PR}"
+MAINTAINER = "mtda-users <mtda-users@googlegroups.com>"
 
 SRC_URI = "https://github.com/pyodide/pyodide/releases/download/${PV}/${PN}-${PV}.tar.bz2"
 SRC_URI[sha256sum] = "85395f34a808cc8852f3c4a5f5d47f906a8a52fa05e5cd70da33be82f4d86a58"

--- a/meta-isar/recipes-www/pytest-whl/pytest-whl_8.4.1.bb
+++ b/meta-isar/recipes-www/pytest-whl/pytest-whl_8.4.1.bb
@@ -9,6 +9,7 @@ inherit dpkg-raw
 
 PR = "1"
 CHANGELOG_V = "${PV}-${PR}"
+MAINTAINER = "mtda-users <mtda-users@googlegroups.com>"
 
 do_install[network] = "${TASK_USE_NETWORK}"
 do_install() {


### PR DESCRIPTION
Our own packages, as well as the ones we rebuild need correct maintainer information. Add the generic mtda-users entry.