### PR TITLE
fix(grpc): use float for mouse coordinates in proto

### DIFF
--- a/mtda/grpc/mtda.proto
+++ b/mtda/grpc/mtda.proto
@@ -152,8 +152,8 @@ message KeyboardWriteRequest {
 // ---------------------------------------------------------------------------
 
 message MouseMoveRequest {
-    int32 x       = 1;
-    int32 y       = 2;
+    float x       = 1;
+    float y       = 2;
     int32 buttons = 3;
 }
 


### PR DESCRIPTION
The browser sends normalized float coordinates (0.0-1.0) but the MouseMoveRequest proto fields were declared as int32, causing a TypeError when passing floats via gRPC. Change x and y fields to float so normalized coordinates flow through to the HID backend which handles scaling to absolute values internally.