### PR TITLE
refactor(systemd): restart systemd service on failure

### DIFF
--- a/debian/mtda-service.mtda.service
+++ b/debian/mtda-service.mtda.service
@@ -7,6 +7,8 @@ ConditionPathExists=/etc/mtda/config
 [Service]
 Type=notify
 ExecStart=/usr/sbin/mtda-service -n
+Restart=on-failure
+RestartSec=10s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This makes the service a bit more resilient when devices on the mtda device were physically reconnected (e.g. a serial-usb adapter).
If the service now fails it is automatically restarted which avoids the need to restart the service manually.