### PR TITLE
fix(mtda): use correct default constant in usbf storage

### DIFF
--- a/mtda/storage/usbf.py
+++ b/mtda/storage/usbf.py
@@ -81,7 +81,7 @@ class UsbFunctionController(Image):
             if not os.path.exists(self.user_file):
                 sparse = pathlib.Path(self.user_file)
                 sparse.touch()
-                os.truncate(str(sparse), CONSTS.IMAGE_FILESIZE)
+                os.truncate(str(sparse), CONSTS.DEFAULTS.IMAGE_FILESIZE)
 
         if self.user_device is None and self.user_file is None:
             raise RuntimeError("shared storage device/file not defined!")


### PR DESCRIPTION
A similar fix has been applied to the qemu storage in b02521ff.

Fixes: bba9ae67 ("feat(usbf): auto-create file if not available")

Closes: #590 