### PR TITLE
fix(ro-image): create mtda homedir

### DIFF
--- a/meta-isar-extra/recipes-core/images/mtda-image-immutable.bb
+++ b/meta-isar-extra/recipes-core/images/mtda-image-immutable.bb
@@ -15,3 +15,4 @@ require recipes-core/images/mtda-image.bb
 
 # get a hostname via DHCP
 IMAGE_INSTALL:remove = "mtda-hostname"
+IMAGE_INSTALL += "mtda-create-homedir"

--- a/meta-isar-extra/recipes-core/mtda-empty-homedir/files/mtda-create-homedir.tmpfiles
+++ b/meta-isar-extra/recipes-core/mtda-empty-homedir/files/mtda-create-homedir.tmpfiles
@@ -1,0 +1,5 @@
+#
+# Copyright (C) 2026 Siemens AG
+# SPDX-License-Identifier: MIT
+#
+d /var/lib/mtda 700 mtda mtda - -

--- a/meta-isar-extra/recipes-core/mtda-empty-homedir/mtda-create-homedir_0.1.bb
+++ b/meta-isar-extra/recipes-core/mtda-empty-homedir/mtda-create-homedir_0.1.bb
@@ -1,0 +1,17 @@
+# ---------------------------------------------------------------------------
+# This Isar layer is part of MTDA
+# Copyright (C) 2026 Siemens AG
+# ---------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------
+
+inherit dpkg-raw
+
+DESCRIPTION = "create mtda homedir if not present"
+MAINTAINER = "mtda-users <mtda-users@googlegroups.com>"
+
+SRC_URI = "file://${BPN}.tmpfiles"
+
+do_prepare_build:append() {
+    cp ${WORKDIR}/${BPN}.tmpfiles ${S}/debian/
+}


### PR DESCRIPTION
On ro-images we deploy an empty var partition. By that, the mtda homedir in /var/lib/mtda currently does not exist on ro images. To fix this, we just create the (empty) dir with a tmpfiles.d entry, similar to how it is done in isar-cip-core. If the directory is present, nothing is done.

Previously this was not needed, as the copy and creation of /home is automatically handled by isar-cip-core.

Fixes: 28f7d2f4 ("mtda: use /var/lib/mtda as home directory for ...")

CC @bniedermayr 