### PR TITLE
fix(kas): bump cip-core to current master

### DIFF
--- a/kas/opt/ab-rootfs.lock.yml
+++ b/kas/opt/ab-rootfs.lock.yml
@@ -3,4 +3,4 @@ header:
 overrides:
     repos:
         cip-core:
-            commit: 185b390af944e095d803c82d434bd51e74c999fd
+            commit: 9a94aa33303270af38a89802dcd294c93b4c7781


### PR DESCRIPTION
This updates to current cip-core master which, among other things, fixes the swupdate compilation, [by removing the "cross" profile](https://gitlab.com/cip-project/cip-core/isar-cip-core/-/commit/890db11624628a5d24bee0a854005f0d37e2f4f9).

This wouldn't be needed anymore when switching to debian trixie, since swupdate is only compiled for non trixie distributions. But first things first.