### PR TITLE
feat(power/qemu): use virtio-vga for display output

### DIFF
--- a/mtda/power/qemu.py
+++ b/mtda/power/qemu.py
@@ -164,6 +164,7 @@ class QemuController(PowerController):
         options += " -netdev user,id=net0,"
         options += f"hostfwd=tcp::2222-:22,hostname={self.hostname}"
         options += " -device qemu-xhci"
+        options += " -vga virtio"
         options += " -vnc :0,websocket=on"
 
         # extra options


### PR DESCRIPTION
virtio-vga keeps legacy VGA-compatible boot output (BIOS/VESA, UEFI GOP) for guests without a virtio_gpu driver, while transparently giving paravirtualized virtio-gpu to guests that have one loaded.